### PR TITLE
Add Configuration to suppress aggregate logs with no entries

### DIFF
--- a/logBuffer.go
+++ b/logBuffer.go
@@ -105,6 +105,11 @@ func (b *LogBuffer) Write(data []byte) (n int, err error) {
 	return b.Buff.Write(append(newData, []byte(",")...))
 }
 
+// Length - return the length of the aggregate log buffer
+func (b *LogBuffer) Length() int {
+	return b.Buff.Len()
+}
+
 // String - output the strings.Builder as one aggregated JSON object
 func (b *LogBuffer) String() string {
 	var str strings.Builder

--- a/logBuffer_test.go
+++ b/logBuffer_test.go
@@ -43,6 +43,48 @@ func TestLogBuffer_String(t *testing.T) {
 	}
 }
 
+func TestLogBuffer_Length(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		buff     LogBuffer
+		write    []byte
+		expectedLength int
+	}{
+		{
+			name:     "hey",
+			buff:     NewLogBuffer(WithBanner(true), WithHeader("id1", "val1"), WithHeader("id2", "id2")),
+			write:    []byte("\"msg\":\"hey-one\""),
+			expectedLength: 16,
+		},
+		{
+			name:     "hey-now",
+			buff:     NewLogBuffer(WithHeader("hey", "now")),
+			write:    []byte("\"msg\":\"hey-two\""),
+			expectedLength: 16,
+		},
+		{
+			name:     "hey-now",
+			buff:     NewLogBuffer(WithHeader("hey", "now")),
+			write:    []byte("\"msg\":\"hey-three\",\"msg\":\"hey-four\""),
+			expectedLength: 35,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.buff.Write(tt.write)
+			if err != nil {
+				t.Error("LogBuffer.String() Write error: ", err)
+			}
+			fmt.Println("buff == ", tt.buff.String())
+
+			if tt.buff.Length() != tt.expectedLength {
+				t.Errorf("LogBuffer.Length() = %v, want %v", tt.buff.Length(), tt.expectedLength)
+			}
+		})
+	}
+}
+
 func TestNewLogBuffer(t *testing.T) {
 	tests := []struct {
 		name string

--- a/middleware.go
+++ b/middleware.go
@@ -117,7 +117,7 @@ func WithTracing(
 				}
 			}
 			if opts.aggregateLogging {
-				if opts.emptyAggregateEntries || (!opts.emptyAggregateEntries && aggregateLoggingBuff.Length() > 0) {
+				if aggregateLoggingBuff.Length() > 0 || opts.emptyAggregateEntries {
 					aggregateLoggingBuff.StoreHeader("request-summary-info", fields)
 					// if useBanner {
 					// 	fields["banner"] = "[GIN] --------------------------------------------------------------- GinLogrusWithTracing ----------------------------------------------------------------"

--- a/middleware.go
+++ b/middleware.go
@@ -117,11 +117,13 @@ func WithTracing(
 				}
 			}
 			if opts.aggregateLogging {
-				aggregateLoggingBuff.StoreHeader("request-summary-info", fields)
-				// if useBanner {
-				// 	fields["banner"] = "[GIN] --------------------------------------------------------------- GinLogrusWithTracing ----------------------------------------------------------------"
-				// }
-				fmt.Fprintf(opts.writer, aggregateLoggingBuff.String())
+				if opts.emptyAggregateEntries || (!opts.emptyAggregateEntries && aggregateLoggingBuff.Length() > 0) {
+					aggregateLoggingBuff.StoreHeader("request-summary-info", fields)
+					// if useBanner {
+					// 	fields["banner"] = "[GIN] --------------------------------------------------------------- GinLogrusWithTracing ----------------------------------------------------------------"
+					// }
+					fmt.Fprintf(opts.writer, aggregateLoggingBuff.String())
+				}
 			}
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -11,6 +11,7 @@ import (
 type Option func(*options)
 type options struct {
 	aggregateLogging bool
+	emptyAggregateEntries bool
 	logLevel         logrus.Level
 	writer           io.Writer
 	banner           string
@@ -19,6 +20,7 @@ type options struct {
 // defaultOptions - some defs options to NewJWTCache()
 var defaultOptions = options{
 	aggregateLogging: false,
+	emptyAggregateEntries: true,
 	logLevel:         logrus.DebugLevel,
 	writer:           os.Stdout,
 	banner:           DefaultBanner,
@@ -28,6 +30,13 @@ var defaultOptions = options{
 func WithAggregateLogging(a bool) Option {
 	return func(o *options) {
 		o.aggregateLogging = a
+	}
+}
+
+// WithEmptyAggregateEntries - define an Option func for printing aggregate logs with empty entries
+func WithEmptyAggregateEntries(a bool) Option {
+	return func(o *options) {
+		o.emptyAggregateEntries = a
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -25,6 +25,26 @@ func TestWithAggregateLogging(t *testing.T) {
 	}
 }
 
+func TestWithEmptyAggregateEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "true", want: true},
+		{name: "false", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := defaultOptions
+			f := WithEmptyAggregateEntries(tt.want)
+			f(&opts)
+			if opts.emptyAggregateEntries != tt.want {
+				t.Errorf("WithEmptyAggregateEntries() = %v, want %v", opts.emptyAggregateEntries, tt.want)
+			}
+		})
+	}
+}
+
 func TestWithLogLevel(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
When using aggregate logging, messages will be printed even if no entries exist for a request. This PR adds `WithEmptyAggregateEntries()` which defaults to true (existing behavior). When set to false, if there are no log entries for a specific request the base aggregate log entry isn't printed.

Usage:
```
e.Use(ginlogrus.WithTracing(logrus.StandardLogger(),
		useBanner,
		time.RFC3339,
		useUTC,
		"requestID",
		[]byte("uber-trace-id"),
		[]byte("RequestID"), 
		ginlogrus.WithAggregateLogging(true),
		ginlogrus.WithEmptyAggregateEntries(false),
		ginlogrus.WithLogLevel(logrus.ErrorLevel)))
```