### PR TITLE
Addition Option for specifying a reducedLogging function 

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -2,6 +2,7 @@ package ginlogrus
 
 import (
 	"bytes"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -160,4 +161,130 @@ func TestBanner(t *testing.T) {
 	t.Log("this is the buffer: ", l)
 	is.True(strings.Contains(l.String(), customBanner))
 
+}
+
+func TestLogMessageWithProductionLevelReducedLogging(t *testing.T) {
+	is := is.New(t)
+	buff := ""
+	getHandler := func(c *gin.Context) {
+		SetCtxLoggerHeader(c, "ReducedLogging", "Shouldn't have messages with a 2xx response")
+
+		logger := GetCtxLogger(c)
+		logger.Info("test-entry-1")
+		logger.Info("test-entry-2")
+		logger.Error("error-entry-1")
+		c.JSON(200, "Hello world!")
+	}
+	failHandler := func(c *gin.Context) {
+		SetCtxLoggerHeader(c, "ReducedLogging", "Shouldn't have messages with a 2xx response")
+		logger := GetCtxLogger(c)
+		logger.Info("test-entry-1")
+		logger.Info("test-entry-2")
+		logger.Error("error-entry-1")
+		c.JSON(401, "Hello fail!")
+	}
+	gin.SetMode(gin.DebugMode)
+	gin.DisableConsoleColor()
+
+	l := bytes.NewBufferString(buff)
+	r := gin.Default()
+	r.Use(WithTracing(logrus.StandardLogger(),
+		false,
+		time.RFC3339,
+		true,
+		"requestID",
+		[]byte("uber-trace-id"), // where jaeger might have put the trace id
+		[]byte("RequestID"),     // where the trace ID might already be populated in the headers
+		WithAggregateLogging(true),
+		WithWriter(l),
+		WithReducedLoggingFunc(productionLoggingTestFunc),
+	))
+	r.GET("/", getHandler)
+	r.GET("/fail", failHandler)
+	w := performRequest("GET", "/", r)
+	is.Equal(200, w.Code)
+	t.Log("this is the buffer: ", l)
+	// Beacuase the request is a 2xx we will not have any log entries including possible errors
+	is.True(len(l.String()) == 0)
+	is.True(!strings.Contains(l.String(), "test-entry-1"))
+	is.True(!strings.Contains(l.String(), "test-entry-2"))
+	is.True(!strings.Contains(l.String(), "error-entry-1"))
+
+	w = performRequest("GET", "/fail", r)
+	is.Equal(401, w.Code)
+	t.Log("this is the buffer: ", l)
+	// Beacuase the request is a 401 we will have all log entries including info logs
+	is.True(len(l.String()) > 0)
+	is.True(strings.Contains(l.String(), "test-entry-1"))
+	is.True(strings.Contains(l.String(), "test-entry-2"))
+	is.True(strings.Contains(l.String(), "error-entry-1"))
+
+}
+
+func TestLogMessageWithProductionReducedLoggingWarnLevel(t *testing.T) {
+	is := is.New(t)
+	buff := ""
+	getHandler := func(c *gin.Context) {
+		SetCtxLoggerHeader(c, "ReducedLogging", "Shouldn't have messages with a 2xx response")
+
+		logger := GetCtxLogger(c)
+		logger.Info("test-entry-1")
+		logger.Info("test-entry-2")
+		logger.Error("error-entry-1")
+		c.JSON(200, "Hello world!")
+	}
+	failHandler := func(c *gin.Context) {
+		SetCtxLoggerHeader(c, "ReducedLogging", "Shouldn't have messages with a 2xx response")
+		logger := GetCtxLogger(c)
+		logger.Info("test-entry-1")
+		logger.Info("test-entry-2")
+		logger.Error("error-entry-1")
+		c.JSON(401, "Hello fail!")
+	}
+	gin.SetMode(gin.DebugMode)
+	gin.DisableConsoleColor()
+
+	l := bytes.NewBufferString(buff)
+	r := gin.Default()
+	r.Use(WithTracing(logrus.StandardLogger(),
+		false,
+		time.RFC3339,
+		true,
+		"requestID",
+		[]byte("uber-trace-id"), // where jaeger might have put the trace id
+		[]byte("RequestID"),     // where the trace ID might already be populated in the headers
+		WithAggregateLogging(true),
+		WithWriter(l),
+		WithLogLevel(logrus.WarnLevel),
+		WithReducedLoggingFunc(productionLoggingTestFunc),
+	))
+	r.GET("/", getHandler)
+	r.GET("/fail", failHandler)
+	w := performRequest("GET", "/", r)
+	is.Equal(200, w.Code)
+	t.Log("this is the buffer: ", l)
+	// Beacuase the request is a 2xx we will not have any log entries including possible errors
+	is.True(len(l.String()) == 0)
+	is.True(!strings.Contains(l.String(), "test-entry-1"))
+	is.True(!strings.Contains(l.String(), "test-entry-2"))
+	is.True(!strings.Contains(l.String(), "error-entry-1"))
+
+	w = performRequest("GET", "/fail", r)
+	is.Equal(401, w.Code)
+	t.Log("this is the buffer: ", l)
+	// Beacuase the request is a 401 we will have log entries but because we have our log level at WARN we will not have info logs
+	is.True(len(l.String()) > 0)
+	is.True(!strings.Contains(l.String(), "test-entry-1"))
+	is.True(!strings.Contains(l.String(), "test-entry-2"))
+	is.True(strings.Contains(l.String(), "error-entry-1"))
+
+}
+
+// Same production logging function that will only log on statusCodes in a certain range
+func productionLoggingTestFunc(c *gin.Context) bool {
+	statusCode := c.Writer.Status()
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return true
+	}
+	return false
 }

--- a/options.go
+++ b/options.go
@@ -4,26 +4,32 @@ import (
 	"io"
 	"os"
 
+	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
 
 // Option - define options for WithTracing()
 type Option func(*options)
+
+type ReducedLoggingFunc func(c *gin.Context) bool
+
 type options struct {
-	aggregateLogging bool
+	aggregateLogging      bool
+	logLevel              logrus.Level
 	emptyAggregateEntries bool
-	logLevel         logrus.Level
-	writer           io.Writer
-	banner           string
+	reducedLoggingFunc    ReducedLoggingFunc
+	writer                io.Writer
+	banner                string
 }
 
 // defaultOptions - some defs options to NewJWTCache()
 var defaultOptions = options{
-	aggregateLogging: false,
+	aggregateLogging:      false,
+	logLevel:              logrus.DebugLevel,
 	emptyAggregateEntries: true,
-	logLevel:         logrus.DebugLevel,
-	writer:           os.Stdout,
-	banner:           DefaultBanner,
+	reducedLoggingFunc:    func(c *gin.Context) bool { return true },
+	writer:                os.Stdout,
+	banner:                DefaultBanner,
 }
 
 // WithAggregateLogging - define an Option func for passing in an optional aggregateLogging
@@ -37,6 +43,13 @@ func WithAggregateLogging(a bool) Option {
 func WithEmptyAggregateEntries(a bool) Option {
 	return func(o *options) {
 		o.emptyAggregateEntries = a
+	}
+}
+
+// WithEmptyAggregateEntries - define an Option func for printing aggregate logs with empty entries
+func WithReducedLoggingFunc(a ReducedLoggingFunc) Option {
+	return func(o *options) {
+		o.reducedLoggingFunc = a
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -11,6 +11,8 @@ import (
 // Option - define options for WithTracing()
 type Option func(*options)
 
+// Function definition for reduced logging. The return value of this function
+// will be used to determine whether or not a log will be output.
 type ReducedLoggingFunc func(c *gin.Context) bool
 
 type options struct {
@@ -46,7 +48,7 @@ func WithEmptyAggregateEntries(a bool) Option {
 	}
 }
 
-// WithEmptyAggregateEntries - define an Option func for printing aggregate logs with empty entries
+// WithReducedLoggingFunc - define an Option func for reducing logs based on a custom function
 func WithReducedLoggingFunc(a ReducedLoggingFunc) Option {
 	return func(o *options) {
 		o.reducedLoggingFunc = a


### PR DESCRIPTION
Users can specify a function to determine whether to log a message or not. The function will take in a gin context meaning that logs can be based on attributes of the context like the request StatusCode or the request latency.